### PR TITLE
[PDI-12267] - Weka Scoring Step Plug-in Help does not work

### DIFF
--- a/src/org/pentaho/di/scoring/WekaScoringMeta.java
+++ b/src/org/pentaho/di/scoring/WekaScoringMeta.java
@@ -63,7 +63,9 @@ import weka.core.SerializedObject;
  * 
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}org)
  */
-@Step(id = "WekaScoring", image = "WS.png", name = "Weka Scoring", description = "Appends predictions from a pre-built Weka model", categoryDescription = "Data Mining")
+@Step(id = "WekaScoring", image = "WS.png", name = "Weka Scoring",
+  description = "Appends predictions from a pre-built Weka model", categoryDescription = "Data Mining",
+  documentationUrl = "http://wiki.pentaho.com/display/DATAMINING/Using+the+Weka+Scoring+Plugin")
 public class WekaScoringMeta extends BaseStepMeta implements StepMetaInterface {
 
   protected static Class<?> PKG = WekaScoringMeta.class;


### PR DESCRIPTION
[PDI-12267] - Weka Scoring Step Plug-in Help does not work

added the link to the documentationUrl annotation to the WekaScoringMeta.java
